### PR TITLE
修改了 quick_start.sh和get_normal.py两个文件中存在错误的地方

### DIFF
--- a/get_normal.py
+++ b/get_normal.py
@@ -19,7 +19,7 @@ def main():
         "Stable-X/StableNormal",
         "StableNormal",
         trust_repo=True,
-        local_cache_dir="/home/lff/bigdata1/cjw/model_cache"
+        local_cache_dir="~/.cache/langscenex_models"
     )
     if not args.video_process:
         base_path = args.base_path

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -5,7 +5,7 @@ last_image=$2
 
 sam_model_path="./sam_vit_h_4b8939.pth"
 sam2_model_path="./sam2_hiera_large.pt"
-model_path="./CogVideo-X"
+model_path="./CogVideoX-ft"
 
 mkdir -p demo/rgb
 cp $first_image demo/rgb/0001.png
@@ -22,7 +22,7 @@ python auto-seg/auto-mask-align.py \
 # get normal maps
 python get_normal.py --base_path demo
 
-RGB video interpolation
+# RGB video interpolation
 python video_inference.py \
     --model_path $model_path \
     --output_dir demo/video/rgb \


### PR DESCRIPTION
1. quick_start.sh 的纯文本未注释
原脚本中有一行：
RGB video interpolation
它不是注释，shell 会把它当命令执行。
解决方法：
已将相关说明文字修为注释。

2. quick_start.sh 中 CogVideo 目录名不正确
原脚本写的是：
./CogVideo-X
但实际更合理的目录命名应为：
./CogVideoX-ft
否则 diffusers 会将 ./CogVideo-X 当作非法 Hugging Face repo id 处理。
解决方法：
已修正 quick_start.sh 中的默认路径。

3. get_normal.py 使用作者机器上的绝对缓存路径
原代码中硬编码：
/home/lff/bigdata1/cjw/model_cache
这显然是作者本地机器路径，导致在当前机器上调用 StableNormal 时失败。
解决方法：
已将 get_normal.py 改为使用当前用户目录下的本地缓存：
~/.cache/langscenex_models
这让代码变为可移植状态。